### PR TITLE
Showcase on gh-pages and linked on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,6 @@
 # About
 
-October [data jam](http://www.meetup.com/Houston-Data-Visualization-Meetup/events/226018977/) with Houston housing data
-
-# Showcase
-
-* [Days on market &amp; to closing by subdivision](http://pandafulmanda.github.io/data-jam-october-2015/)
-  * [Code](https://github.com/pandafulmanda/data-jam-october-2015)
+October [data jam](http://houstondatavis.github.io/data-jam-october-2015/) with Houston housing data
 
 # Data set features
 


### PR DESCRIPTION
Fixes #5 with gh-pages in this repo.

This way, plots and code links can be to
- merged in html from the vis and not require separate hosting, or
- external links/other repos/gh-pages
### For both submitted vis,
- [x] add link to plots
- [x] add link to code
